### PR TITLE
DEVOPS-668: bump chartjs for security

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/aha-app/pghero#readme",
   "dependencies": {
-    "chart.js": "2.5.0",
+    "chart.js": "2.9.4",
     "chartkick": "^2.2.4",
     "highlight.js": "^9.12.0",
     "jquery": "^3.5.1"


### PR DESCRIPTION
Bump chart.js to 2.9.4 for security.